### PR TITLE
fix: misc fixes before shipping 2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.24)
 
 project( verifier
 	DESCRIPTION "A tool used to verify a game's install."
-	VERSION 0.2.1
+	VERSION 0.2.2
 )
 set( CMAKE_CXX_STANDARD 20 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,8 @@ auto main( int argc, char* argv[] ) -> int {
 		excludes.emplace_back( "sdk_content.*" );
 		excludes.emplace_back( ".*\\.vmf_autosave.*" );
 		excludes.emplace_back( ".*\\.vmx" );
-		excludes.emplace_back( ".*index\\.rsv" );
+		excludes.emplace_back( ".*\\.log" );
+		excludes.emplace_back( ".*verifier_index\\.rsv" );
 		ret = create( root, indexLocation, excludes, overwrite, output.get() );
 	} else {
 		// warn about stuff which shouldn't be here, don't use the `output::report` as this is a negligible user error


### PR DESCRIPTION
- Exclude `*.log` by default
- Default filename of index is now `verifier_index.rsv`, update the exclusion regex