### PR TITLE
fix: normalize slashes of stored vpk paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.24)
 
 project( verifier
 	DESCRIPTION "A tool used to verify a game's install."
-	VERSION 0.3.0
+	VERSION 0.3.1
 )
 set( CMAKE_CXX_STANDARD 20 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -70,7 +70,8 @@ auto createFromRoot( std::string_view root_, std::string_view indexLocation, boo
 		}
 
 		// relative path
-		const auto pathRel{ std::filesystem::relative( path, root ).string() };
+		auto pathRel{ std::filesystem::relative( path, root ).string() };
+		sourcepp::string::normalizeSlashes( pathRel );
 
 		auto breaker{ false };
 		for ( const auto& exclusion : exclusionREs ) {


### PR DESCRIPTION
Minor patch, now all filepaths are stored with forward slashes in the index